### PR TITLE
Fix permissions for editing facility address

### DIFF
--- a/IAIP/Facility/IAIPFacilitySummary.vb
+++ b/IAIP/Facility/IAIPFacilitySummary.vb
@@ -70,11 +70,7 @@ Public Class IAIPFacilitySummary
         ToolsMenuSeparator.Visible = (CreateFacilityMenuItem.Available AndAlso UpdateEpaMenuItem.Available)
 
         ' Edit location/header data
-        If CurrentUser.UnitId = 0 OrElse AccountFormAccess(22, 3) = "1" OrElse AccountFormAccess(1, 3) = "1" Then
-            EditFacilityLocationButton.Visible = True
-        Else
-            EditFacilityLocationButton.Visible = False
-        End If
+        EditFacilityLocationButton.Visible = CurrentUser.HasPermission(UserCan.EditFacilityAddress)
     End Sub
 
     Private Sub InitializeDataTables()

--- a/IAIP/Facility/Sub Forms/IAIPEditFacilityLocation.vb
+++ b/IAIP/Facility/Sub Forms/IAIPEditFacilityLocation.vb
@@ -105,7 +105,7 @@ Public Class IAIPEditFacilityLocation
     End Sub
 
     Private Sub Save()
-        If Not (AccountFormAccess(28, 2) = "1" OrElse AccountFormAccess(28, 3) = "1" OrElse AccountFormAccess(28, 4) = "1") Then
+        If Not CurrentUser.HasPermission(UserCan.EditFacilityAddress) Then
             MessageBox.Show("You do not have permissions to change facility location information.")
             Return
         End If

--- a/IAIP/_Data Models/Users/IaipUser.vb
+++ b/IAIP/_Data Models/Users/IaipUser.vb
@@ -106,6 +106,11 @@
                 Return HasRole({102, 114, 2, 19, 28}) OrElse
                     HasRoleType(RoleType.DistrictManager)
 
+            Case UserCan.EditFacilityAddress
+                ' ISMP Program Manager, SSCP Program Manager, District Liaison, SSPP Program Manager,
+                ' SSPP Administrative, Branch Chief, SSCP Unit Manager, SSPP Unit Manager
+                Return HasRole({2, 19, 27, 28, 29, 102, 114, 121})
+
             Case UserCan.ShutDownFacility
                 ' SSCP Unit Manager, SSCP Program Manager, Branch Chief, District Liaison, SSPP Program Manager
                 Return HasRole({114, 19, 102, 27, 28})
@@ -197,6 +202,7 @@ Public Enum UserCan
     ResolveEnforcement
     AddPollutantsToFacility
     EditFacilityHeaderData
+    EditFacilityAddress
     ShutDownFacility
     CreateFacility
     EditAllUsers


### PR DESCRIPTION
The button to open the facility address editor and the button to save changes to the facility address had different permissions. I added a new permission that looks reasonable to me and used it for both.