### PR TITLE
Don't round the invoice amount in the Fees Audit form

### DIFF
--- a/IAIP/AnnualFees/FeesAudit.vb
+++ b/IAIP/AnnualFees/FeesAudit.vb
@@ -906,7 +906,7 @@ Public Class FeesAudit
             End If
 
             SQL = "Select " &
-            "convert(int, InvoiceID) as InvoiceID, convert(int, numAmount) as numAmount, " &
+            "convert(int, InvoiceID) as InvoiceID, numAmount, " &
             "datInvoiceDate, strComment, " &
             "strPayTypeDesc, " &
             "case " &


### PR DESCRIPTION
Invoice amount was converted to `int` in the SQL query.