### PR TITLE
Fix query generator when second county is selected

### DIFF
--- a/IAIP/Universal Forms/IAIPQueryGenerator.vb
+++ b/IAIP/Universal Forms/IAIPQueryGenerator.vb
@@ -84,7 +84,7 @@ Public Class IAIPQueryGenerator
     Private Sub LoadDataSets()
         Try
 
-            query = "Select strCountyCode, strCountyName, strAttainmentStatus " &
+            query = "Select strCountyCode, strCountyName " &
             "from LookUpCountyInformation " &
             "order by strCountyName "
 
@@ -170,6 +170,7 @@ Public Class IAIPQueryGenerator
         With cboCountySearch2
             .DataSource = dtcboCountySearch2
             .DisplayMember = "strCountyName"
+            .ValueMember = "strCountyCode"
             .SelectedIndex = -1
         End With
 


### PR DESCRIPTION
The second county combobox did not have a value member set, so selecting a second county resulted in the whole DataRowView being set as the SqlParameter value, resulting in an exception.