### PR TITLE
Fix crash when clearing Facility Summary

### DIFF
--- a/IAIP/Facility/IAIPFacilitySummary.vb
+++ b/IAIP/Facility/IAIPFacilitySummary.vb
@@ -923,6 +923,7 @@ Public Class IAIPFacilitySummary
     End Sub
 
     Private Sub ClearFormToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ClearFormMenuItem.Click
+        AddBreadcrumb($"Facility Summary: clear form", Me)
         AirsNumber = Nothing
     End Sub
 
@@ -947,6 +948,8 @@ Public Class IAIPFacilitySummary
 #Region " Form-level events "
 
     Private Sub FSMainTabControl_SelectedIndexChanged(sender As Object, e As EventArgs) Handles FSMainTabControl.SelectedIndexChanged
+        If AirsNumber Is Nothing Then Return
+
         Cursor = Cursors.WaitCursor
 
         Dim data As New Dictionary(Of String, Object) From {


### PR DESCRIPTION
If a tab other than "Summary" is selected when clearing the Facility Summary form, then a tab control change event is fired. The handler of that event tries to add a Raygun breadcrumb based on the AIRS number which is null at that point.

A null check has been added (and an appropriate breadcrumb added earlier in the call stack).

fixes #1165 