### PR TITLE
Load info in permit uploader even if facility data doesn't exist yet

### DIFF
--- a/IAIP/SSPP/SSPPPermitUploader.vb
+++ b/IAIP/SSPP/SSPPPermitUploader.vb
@@ -80,7 +80,7 @@ Public Class SSPPPermitUploader
                 "from SSPPApplicationMaster " &
                 "left join SSPPApplicationTracking " &
                 "on SSPPApplicationMaster.strApplicationNumber  = SSPPApplicationTracking.strApplicationNumber " &
-                "inner join APBFacilityInformation " &
+                "left join APBFacilityInformation " &
                 "on SSPPApplicationMaster.strAIRSNumber = APBFacilityInformation.strAIRSNumber  " &
                 "left join LookUpCountyInformation " &
                 "on SUBSTRING(SSPPApplicationMaster.strAIRSnumber, 5, 3)  = LookUpCountyInformation.strCountyCode " &
@@ -88,7 +88,7 @@ Public Class SSPPPermitUploader
                 "on SSPPApplicationMaster.strApplicationType = LookUpApplicationTypes.strApplicationTypeCode " &
                 "left join LookUpPermitTypes " &
                 "on SSPPApplicationMaster.strPermitType = LookUpPermitTypes.strPermitTypeCode " &
-                "inner join EPDUserProfiles " &
+                "left join EPDUserProfiles " &
                 "on SSPPApplicationMaster.strStaffResponsible = EPDUserProfiles.numUserID " &
                 "where ssppapplicationtracking.strApplicationNumber = @appnum "
 


### PR DESCRIPTION
There was an `inner join` on the `APBFACILITYINFORMATION` table, but no data exists in that table yet, so no record was returned. The facility data is only displayed to the user and not used for any other purpose. Plus there was already code to handle missing facility data. So changing the query to an `outer join` will fix the issue.

The only question is why no one has complained about this before. Maybe they just uploaded files regardless of the displayed info. Or maybe they waited until the table was populated to upload files. Either way, I know of no downside to fixing this.

fixes #1199 