### PR TITLE
Fix for ACC reports showing editable fields when complete

### DIFF
--- a/IAIP/SSCP/SSCPEvents.vb
+++ b/IAIP/SSCP/SSCPEvents.vb
@@ -2012,6 +2012,9 @@ Public Class SSCPEvents
                 chbACCReceivedByAPB.Enabled = True
                 dtpAccReportingYear.Enabled = True
             End If
+
+            CompleteReport()
+
         Catch ex As Exception
             ErrorReport(ex, Me.Name & "." & Reflection.MethodBase.GetCurrentMethod.Name)
         End Try


### PR DESCRIPTION
The form was not checking if the ACC was complete after switching between submittals.

fixes #1193 