### PR TITLE
Fix the default year in the compliance manager tools

### DIFF
--- a/IAIP/SSCP/SSCPManagersTools.vb
+++ b/IAIP/SSCP/SSCPManagersTools.vb
@@ -48,7 +48,10 @@ Public Class SSCPManagersTools
                 .DataSource = DB.GetDataTable(SQL)
                 .DisplayMember = "INTYEAR"
                 .ValueMember = "INTYEAR"
+                .SelectedIndex = 0
             End With
+
+            If DateTime.Today.Month < 10 Then cboFiscalYear.SelectedIndex = 1
 
             SQL = "SELECT DISTINCT INTYEAR
                 FROM SSCPINSPECTIONSREQUIRED


### PR DESCRIPTION
The current year is selected during January - September. From October to December, the following year is selected.