### PR TITLE
Fix length of pond and gas emission rate field

### DIFF
--- a/IAIP/ISMP/ISMPTestReports.Designer.vb
+++ b/IAIP/ISMP/ISMPTestReports.Designer.vb
@@ -4701,7 +4701,7 @@ Partial Class ISMPTestReports
         'txtAllowableEmissionRate1Gas
         '
         Me.txtAllowableEmissionRate1Gas.Location = New System.Drawing.Point(135, 30)
-        Me.txtAllowableEmissionRate1Gas.MaxLength = 11
+        Me.txtAllowableEmissionRate1Gas.MaxLength = 10
         Me.txtAllowableEmissionRate1Gas.Name = "txtAllowableEmissionRate1Gas"
         Me.txtAllowableEmissionRate1Gas.Size = New System.Drawing.Size(88, 20)
         Me.txtAllowableEmissionRate1Gas.TabIndex = 194


### PR DESCRIPTION
Every other corresponding emission rate field is 11 characters in the database, but this one only goes to 10. Insert Spinal Tap joke here.

fixes #1249 