### PR TITLE
Fix the link to generate a permit fees email

### DIFF
--- a/IAIP/_Code/Email.vb
+++ b/IAIP/_Code/Email.vb
@@ -70,12 +70,11 @@ Public Module Email
 
 
             If emailUriString.Length < 2084 Then
-                ' The OpenUrl method is preferable, but is limited by URI length, 
-                ' which can be exceeded if a lot of recipients are added
+                ' This method is preferable, but is limited by URI length, which can be exceeded if a lot of recipients are added.
                 ' Ref: https://support.microsoft.com/en-us/help/208427/maximum-url-length-is-2-083-characters-in-internet-explorer
-                result = OpenUrl(New Uri(emailUriString), isMailto:=True)
+                result = OpenUriString(emailUriString, isMailto:=True)
             Else
-                ' Failover is to create a text file with instructions to user
+                ' Failover is to create a text file with instructions to user.
                 OpenEmailAsTextFile(subject, body, toParam, cc, bcc)
                 result = True
             End If

--- a/IAIP/_Code/UrlHelpers/UrlHandler.vb
+++ b/IAIP/_Code/UrlHelpers/UrlHandler.vb
@@ -4,10 +4,10 @@
 
         Public Function OpenUrl(url As Uri, Optional sender As Form = Nothing, Optional isMailto As Boolean = False) As Boolean
             ArgumentNotNull(url, NameOf(url))
-            Return OpenUri(url.ToString, sender, isMailto)
+            Return OpenUriString(url.ToString, sender, isMailto)
         End Function
 
-        Private Function OpenUri(uriString As String, Optional sender As Form = Nothing, Optional isMailto As Boolean = False) As Boolean
+        Public Function OpenUriString(uriString As String, Optional sender As Form = Nothing, Optional isMailto As Boolean = False) As Boolean
             ' Reference: https://faithlife.codes/blog/2008/01/using_processstart_to_link_to/
             Try
                 If sender IsNot Nothing Then sender.Cursor = Cursors.AppStarting


### PR DESCRIPTION
Reported by Joe A.

After either upgrading to Windows 11 or the new Outlook (or both), the link to generate an email from the permit application fees tab has stopped working.

The current process for generating emails creates a URL-encoded `mailto` string, which is converted to a `Uri` object, which is then converted back to a string to send to the `Process.Start` method. This back and forth causes the space characters in the string to be decoded from `%20` back to regular spaces. Apparently, this worked fine in the old Outlook, but the new Outlook tries to parse each space-delimited segment separately, causing it to get overwhelmed.