### PR TITLE
Improve AIRS number string parsing

### DIFF
--- a/IAIP.Test/ControlTests/AirsNumberTextBoxTests.vb
+++ b/IAIP.Test/ControlTests/AirsNumberTextBoxTests.vb
@@ -5,42 +5,38 @@ Public Class AirsNumberTextBoxTests
 
     <Fact>
     Private Sub InitialValues()
-        Using airs As New AirsNumberTextBox()
-            Assert.Null(airs.AirsNumber)
-            Assert.Equal(9, airs.MaxLength)
-            Assert.Equal("000-00000", airs.Cue)
-            Assert.False(airs.FacilityMustExist)
-            Assert.Equal(AirsNumberValidationResult.Empty, airs.ValidationStatus)
+        Using airsTextBox As New AirsNumberTextBox()
+            Assert.Null(airsTextBox.AirsNumber)
+            Assert.Equal(9, airsTextBox.MaxLength)
+            Assert.Equal("000-00000", airsTextBox.Cue)
+            Assert.False(airsTextBox.FacilityMustExist)
+            Assert.Equal(AirsNumberValidationResult.Empty, airsTextBox.ValidationStatus)
         End Using
     End Sub
 
-    <Theory>
-    <InlineData("111")>
-    <InlineData("ABC")>
-    <InlineData("0010001")>
-    <InlineData("001-0001")>
-    Private Sub InvalidFormat(input As String)
-        Using airs As New AirsNumberTextBox With {.Text = input}
-            Dim result As Boolean = airs.Validate()
+    <Fact>
+    Private Sub InvalidFormat()
+        Dim input As String = "invalid"
+
+        Using airsTextBox As New AirsNumberTextBox With {.Text = input}
+            Dim result As Boolean = airsTextBox.Validate()
 
             Assert.True(result)
-            Assert.Equal(AirsNumberValidationResult.InvalidFormat, airs.ValidationStatus)
-            Assert.Equal(input, airs.Text)
+            Assert.Equal(AirsNumberValidationResult.InvalidFormat, airsTextBox.ValidationStatus)
+            Assert.Equal(input, airsTextBox.Text)
         End Using
     End Sub
 
-    <Theory>
-    <InlineData("00100001")>
-    <InlineData("001-00001")>
-    <InlineData("99999999")>
-    <InlineData("999-99999")>
-    Private Sub ValidInput(input As String)
-        Using airs As New AirsNumberTextBox With {.Text = input}
-            Dim result As Boolean = airs.Validate()
+    <Fact>
+    Private Sub ValidInput()
+        Dim input As String = "00199999"
+
+        Using airsTextBox As New AirsNumberTextBox With {.Text = input}
+            Dim result As Boolean = airsTextBox.Validate()
 
             Assert.True(result)
-            Assert.Equal(AirsNumberValidationResult.Valid, airs.ValidationStatus)
-            Assert.Equal(String.Concat(input.Substring(0, 3), "-", input.Substring(input.Length - 5)), airs.Text)
+            Assert.Equal(AirsNumberValidationResult.Valid, airsTextBox.ValidationStatus)
+            Assert.Equal(String.Concat(input.Substring(0, 3), "-", input.Substring(input.Length - 5)), airsTextBox.Text)
         End Using
     End Sub
 
@@ -48,33 +44,33 @@ Public Class AirsNumberTextBoxTests
     <InlineData(Nothing)>
     <InlineData("")>
     Private Sub EmptyInput(input As String)
-        Using airs As New AirsNumberTextBox With {.Text = input}
-            Dim result As Boolean = airs.Validate()
+        Using airsTextBox As New AirsNumberTextBox With {.Text = input}
+            Dim result As Boolean = airsTextBox.Validate()
 
             Assert.True(result)
-            Assert.Equal(AirsNumberValidationResult.Empty, airs.ValidationStatus)
-            Assert.Equal(String.Empty, airs.Text)
+            Assert.Equal(AirsNumberValidationResult.Empty, airsTextBox.ValidationStatus)
+            Assert.Equal(String.Empty, airsTextBox.Text)
         End Using
     End Sub
 
     <Fact>
     Private Sub ValidationStatusChanged()
-        Using airs As New AirsNumberTextBox()
-            AddHandler airs.ValidationStatusChanged, AddressOf Airs_ValidationStatusChanged
+        Using airsTextBox As New AirsNumberTextBox()
+            AddHandler airsTextBox.ValidationStatusChanged, AddressOf Airs_ValidationStatusChanged
 
-            Assert.Null(airs.Tag)
+            Assert.Null(airsTextBox.Tag)
 
-            airs.Text = "001-00001"
-            airs.Validate()
+            airsTextBox.Text = "001-00001"
+            airsTextBox.Validate()
 
-            Assert.NotNull(airs.Tag)
-            Assert.True(CBool(airs.Tag))
+            Assert.NotNull(airsTextBox.Tag)
+            Assert.True(CBool(airsTextBox.Tag))
         End Using
     End Sub
 
     Private Sub Airs_ValidationStatusChanged(sender As Object, e As EventArgs)
-        Dim airs As AirsNumberTextBox = CType(sender, AirsNumberTextBox)
-        airs.Tag = True
+        Dim airsTextBox As AirsNumberTextBox = CType(sender, AirsNumberTextBox)
+        airsTextBox.Tag = True
     End Sub
 
 End Class

--- a/IAIP.Test/ModelTests/ApbFacilityIdTest.vb
+++ b/IAIP.Test/ModelTests/ApbFacilityIdTest.vb
@@ -39,6 +39,7 @@ Public Class ApbFacilityIdTest
     <InlineData("01-1")>
     <InlineData("01-10")>
     <InlineData("01-99999")>
+    <InlineData("041300100001")>
     Private Sub AcceptsValidAirsNumbers(input As String)
         Assert.True(IsValidAirsNumberFormat(input))
     End Sub
@@ -48,7 +49,11 @@ Public Class ApbFacilityIdTest
     <InlineData("")>
     <InlineData("111")>
     <InlineData("ABC")>
-    <InlineData("041300100001")>
+    <InlineData("04130010000")>
+    <InlineData("041300200001")>
+    <InlineData("041332300001")>
+    <InlineData("041300000001")>
+    <InlineData("041300100000")>
     <InlineData("04-13-001-00001")>
     <InlineData("0413-001-0001")>
     <InlineData("abc-defgh")>

--- a/IAIP.Test/ModelTests/ApbFacilityIdTest.vb
+++ b/IAIP.Test/ModelTests/ApbFacilityIdTest.vb
@@ -5,23 +5,72 @@ Imports Xunit
 Public Class ApbFacilityIdTest
 
     <Theory>
+    <InlineData("00100001")>
+    <InlineData("00110000")>
+    <InlineData("00199999")>
+    <InlineData("32100001")>
+    <InlineData("32110000")>
+    <InlineData("32199999")>
+    <InlineData("77700001")>
+    <InlineData("77710000")>
+    <InlineData("77799999")>
+    <InlineData("001-00001")>
+    <InlineData("001-10000")>
+    <InlineData("001-99999")>
+    <InlineData("321-00001")>
+    <InlineData("321-10000")>
+    <InlineData("321-99999")>
+    <InlineData("777-00001")>
+    <InlineData("777-10000")>
+    <InlineData("777-99999")>
+    <InlineData("1-1")>
+    <InlineData("1-10")>
+    <InlineData("1-10000")>
+    <InlineData("1-99999")>
+    <InlineData("321-1")>
+    <InlineData("777-1")>
+    <InlineData("321-10")>
+    <InlineData("777-10")>
+    <InlineData("1-01")>
+    <InlineData("1-10")>
+    <InlineData("1-001")>
+    <InlineData("1-0001")>
+    <InlineData("1-00001")>
+    <InlineData("01-1")>
+    <InlineData("01-10")>
+    <InlineData("01-99999")>
+    Private Sub AcceptsValidAirsNumbers(input As String)
+        Assert.True(IsValidAirsNumberFormat(input))
+    End Sub
+
+    <Theory>
     <InlineData(Nothing)>
     <InlineData("")>
     <InlineData("111")>
     <InlineData("ABC")>
-    <InlineData("0010001")>
-    <InlineData("001-0001")>
-    Private Sub RejectsInvalidAirsNumbers(input As String)
-        Assert.False(IsValidAirsNumberFormat(input))
-    End Sub
-
-    <Theory>
-    <InlineData("00100001")>
-    <InlineData("001-00001")>
     <InlineData("041300100001")>
     <InlineData("04-13-001-00001")>
-    Private Sub AcceptsValidAirsNumbers(input As String)
-        Assert.True(IsValidAirsNumberFormat(input))
+    <InlineData("0413-001-0001")>
+    <InlineData("abc-defgh")>
+    <InlineData("001-0000a")>
+    <InlineData("0100001")>
+    <InlineData("0010001")>
+    <InlineData("00200001")>
+    <InlineData("002-00001")>
+    <InlineData("2-1")>
+    <InlineData("32300001")>
+    <InlineData("323-00001")>
+    <InlineData("323-1")>
+    <InlineData("00000001")>
+    <InlineData("000-00001")>
+    <InlineData("000-99999")>
+    <InlineData("0-1")>
+    <InlineData("00100000")>
+    <InlineData("001-00000")>
+    <InlineData("001-0")>
+    <InlineData("1-0")>
+    Private Sub RejectsInvalidAirsNumbers(input As String)
+        Assert.False(IsValidAirsNumberFormat(input))
     End Sub
 
     <Fact>
@@ -38,19 +87,38 @@ Public Class ApbFacilityIdTest
 
     <Fact>
     Private Sub FacilityIdCTypeWorks()
-        Dim airs2 = CType("123-45678", ApbFacilityId)
+        Dim airs = CType("123-45678", ApbFacilityId)
 
-        Assert.Equal("12345678", airs2.ShortString)
-        Assert.Equal("123", airs2.CountySubstring)
-        Assert.Equal("041312345678", airs2.DbFormattedString)
-        Assert.Equal("GA0000001312345678", airs2.EpaFacilityIdentifier)
-        Assert.Equal("123-45678", airs2.FormattedString)
-        Assert.Equal(12345678, airs2.ToInt)
+        Assert.Equal("12345678", airs.ShortString)
+        Assert.Equal("123", airs.CountySubstring)
+        Assert.Equal("041312345678", airs.DbFormattedString)
+        Assert.Equal("GA0000001312345678", airs.EpaFacilityIdentifier)
+        Assert.Equal("123-45678", airs.FormattedString)
+        Assert.Equal(12345678, airs.ToInt)
+    End Sub
+
+    <Fact>
+    Private Sub AbbreviatedFacilityIdCTypeWorks()
+        Dim airs = CType("1-1", ApbFacilityId)
+
+        Assert.Equal("00100001", airs.ShortString)
+        Assert.Equal("001", airs.CountySubstring)
+        Assert.Equal("041300100001", airs.DbFormattedString)
+        Assert.Equal("GA0000001300100001", airs.EpaFacilityIdentifier)
+        Assert.Equal("001-00001", airs.FormattedString)
+        Assert.Equal(100001, airs.ToInt)
+    End Sub
+
+    <Theory>
+    <InlineData("001-00001", "00100001")>
+    Private Sub FormatNormalizationWorks(input As String, output As String)
+        Dim airs As New ApbFacilityId(input)
+        Assert.Equal(output, airs.ShortString)
     End Sub
 
     <Theory>
     <InlineData("00100001", "001-00001")>
-    <InlineData("041300100001", "04-13-001-00001")>
+    <InlineData("00100001", "1-1")>
     Private Sub EqualityTrue(input1 As String, input2 As String)
         Dim airs1 As New ApbFacilityId(input1)
         Dim airs2 As New ApbFacilityId(input2)
@@ -78,6 +146,7 @@ Public Class ApbFacilityIdTest
 
     <Theory>
     <InlineData("00100001", "001-00001")>
+    <InlineData("00100001", "1-1")>
     Private Sub InequalityFalse(input1 As String, input2 As String)
         Dim airs1 As New ApbFacilityId(input1)
         Dim airs2 As New ApbFacilityId(input2)

--- a/IAIP/_Code/RegexPatterns.vb
+++ b/IAIP/_Code/RegexPatterns.vb
@@ -10,10 +10,11 @@
     ' Valid AIRS number formats are in the form 001-00001 or 00100001 or 1-1.
     ' AIRS numbers consist of a three digit county code and a five-digit facility number.
     ' The county code must be odd and can be in the range of 1 through 321 or 777.
-    ' The facility number can be any positive integer from 1 to 99999.
+    ' The facility number can be any integer from 1 to 99999.
     ' The hyphen is optional. If it is included, then leading zeros are also optional. If excluded, leading zeros are required.
-    ' Test regex here: https://regex101.com/r/2uYyHl/7
-    Friend Const AirsNumberPattern As String = "(?:^(?:777|321|3[0-1][13579]|[0-2][0-9][13579])(?!00000)\d{5})$|^(?:(?:777|321|3[0-1][13579]|[0-2]?[0-9]?[13579])-(?!0{1,5}$)\d{1,5})$"
+    ' (For compatibility, 041300100001 -- without hyphens -- is also accepted. The first four digits must exactly match "0413".
+    ' Test regex here: https://regex101.com/r/2uYyHl/8
+    Friend Const AirsNumberPattern As String = "(?:^(?:0413)?(?:777|321|3[0-1][13579]|[0-2][0-9][13579])(?!00000)\d{5})$|(?:^(?:777|321|3[0-1][13579]|[0-2]?[0-9]?[13579])-(?!0{1,5}$)\d{1,5})$"
 
     ' Valid RMP IDs are in the form 0000-0000-0000 (with the dashes)
     Friend Const RmpIdPattern As String = "^\d{4}-\d{4}-\d{4}$"

--- a/IAIP/_Code/RegexPatterns.vb
+++ b/IAIP/_Code/RegexPatterns.vb
@@ -7,10 +7,13 @@
     Friend Const AtLeastOneLetterPattern As String = "[a-zA-Z]"
     Friend Const NonAlphabeticPattern As String = "[^a-zA-Z]"
 
-    ' Valid AIRS numbers are in the form 000-00000 or 04-13-000-00000
-    ' (with or without the dashes)
-    ' Test regex here: https://regex101.com/r/2uYyHl
-    Friend Const AirsNumberPattern As String = "^(04-?13-?)?\d{3}-?\d{5}$"
+    ' Valid AIRS number formats are in the form 001-00001 or 00100001 or 1-1.
+    ' AIRS numbers consist of a three digit county code and a five-digit facility number.
+    ' The county code must be odd and can be in the range of 1 through 321 or 777.
+    ' The facility number can be any positive integer from 1 to 99999.
+    ' The hyphen is optional. If it is included, then leading zeros are also optional. If excluded, leading zeros are required.
+    ' Test regex here: https://regex101.com/r/2uYyHl/7
+    Friend Const AirsNumberPattern As String = "(?:^(?:777|321|3[0-1][13579]|[0-2][0-9][13579])(?!00000)\d{5})$|^(?:(?:777|321|3[0-1][13579]|[0-2]?[0-9]?[13579])-(?!0{1,5}$)\d{1,5})$"
 
     ' Valid RMP IDs are in the form 0000-0000-0000 (with the dashes)
     Friend Const RmpIdPattern As String = "^\d{4}-\d{4}-\d{4}$"

--- a/IAIP/_DAL/Facilities/FacilityData.vb
+++ b/IAIP/_DAL/Facilities/FacilityData.vb
@@ -218,7 +218,7 @@ Namespace DAL
                 Return AirsNumberValidationResult.Empty
             End If
 
-            If Not Regex.IsMatch(airsInput, AirsNumberPattern) Then
+            If Not IsValidAirsNumberFormat(airsInput) Then
                 Return AirsNumberValidationResult.InvalidFormat
             End If
 
@@ -231,7 +231,7 @@ Namespace DAL
                 Return AirsNumberValidationResult.Empty
             End If
 
-            If Not Regex.IsMatch(airsInput, AirsNumberPattern) Then
+            If Not IsValidAirsNumberFormat(airsInput) Then
                 Return AirsNumberValidationResult.InvalidFormat
             End If
 

--- a/IAIP/_Data Models/Facilities/ApbFacilityId.vb
+++ b/IAIP/_Data Models/Facilities/ApbFacilityId.vb
@@ -136,7 +136,7 @@
         Public Shared Function IsValidAirsNumberFormat(airsNumber As String) As Boolean
             If airsNumber Is Nothing Then Return False
 
-            Return Text.RegularExpressions.Regex.IsMatch(airsNumber, AirsNumberPattern)
+            Return Text.RegularExpressions.Regex.IsMatch(Trim(airsNumber), AirsNumberPattern)
         End Function
 
         ''' <summary>
@@ -146,15 +146,20 @@
         ''' <returns>A string representation of an AIRS number in the form "00000000".</returns>
         <DebuggerStepThrough()>
         Private Shared Function GetNormalizedAirsNumber(airsNumber As String) As String
-            ' Converts a string representation of an AIRS number to the "00000000" form 
-            ' (eight numerals, no dashes).
+            ' Convert a non-normalized string representation of an AIRS number to the normalized form 
+            airsNumber = Trim(airsNumber)
 
-            ' Remove spaces, dashes, and leading '0413'
-            airsNumber = airsNumber.Replace("-", "").Replace(" ", "")
+            Dim dashIndex As Integer = airsNumber.IndexOf("-"c)
+            If dashIndex = -1 Then
+                If airsNumber.Length = 8 Then Return airsNumber
+                Throw New ArgumentException(String.Format("{0} is not a valid AIRS number.", airsNumber))
+            End If
 
-            If airsNumber.Length = 12 Then airsNumber = airsNumber.Remove(0, 4)
+            ' If original string contains a dash, extract the first part and pad to 3 digits
+            Dim countyPart As String = airsNumber.Substring(0, dashIndex).PadLeft(3, "0"c)
+            Dim restPart As String = airsNumber.Substring(dashIndex + 1).Replace("-", "").PadLeft(5, "0"c)
 
-            Return airsNumber
+            Return countyPart & restPart
         End Function
 
         Public Shared Function TryCastApbFacilityId(airsNumber As String) As ApbFacilityId

--- a/IAIP/_Data Models/Facilities/ApbFacilityId.vb
+++ b/IAIP/_Data Models/Facilities/ApbFacilityId.vb
@@ -152,6 +152,12 @@
             Dim dashIndex As Integer = airsNumber.IndexOf("-"c)
             If dashIndex = -1 Then
                 If airsNumber.Length = 8 Then Return airsNumber
+
+                If airsNumber.Length = 12 AndAlso airsNumber.StartsWith("0413") Then
+                    ' If the first four digits are "0413", discard them
+                    Return airsNumber.Substring(4)
+                End If
+
                 Throw New ArgumentException(String.Format("{0} is not a valid AIRS number.", airsNumber))
             End If
 


### PR DESCRIPTION
- Remove obsolete & unused formats
- Make leading zeros optional (when hyphenated only)