### PR TITLE
Log the DB Connection Retry setting

### DIFF
--- a/IAIP/_DAL/Logging/IaipLogging.vb
+++ b/IAIP/_DAL/Logging/IaipLogging.vb
@@ -44,7 +44,8 @@ Namespace DAL
                 New SqlParameter("@DotNetVersion", Get45PlusFromRegistry()),
                 New SqlParameter("@OSVersion", OSFriendlyName()),
                 New SqlParameter("@NetworkStatus", If(isVpn, "On VPN", "In Network")),
-                New SqlParameter("@IaipVersion", GetCurrentVersion().ToString)
+                New SqlParameter("@IaipVersion", GetCurrentVersion().ToString),
+                New SqlParameter("@Comment", If(RetryProviderEnabled, "DB Conn Retry enabled", "DB Conn Retry disabled"))
             }
 
             Try


### PR DESCRIPTION
When logging user system details, include whether the database connection retry strategy is currently enabled.

This PR requires an update to the `dbo.IAIP_SystemLog` table before deployment.